### PR TITLE
Add version support for Chromium on Linux

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -18,7 +18,7 @@ var UserAgent = function() {
         Firefox: /firefox\/([\d\w\.\-]+)/i,
         IE: /msie\s([\d\.]+[\d])|trident\/\d+\.\d+;\s+[rv:]+(\d+\.\d)/i,
         Chrome: /chrome\/([\d\w\.\-]+)/i,
-		Chromium: /crios\/([\d\w\.\-]+)/i,
+        Chromium: /(?:crios|chromium)\/([\d\w\.\-]+)/i,
         Safari: /version\/([\d\w\.\-]+)/i,
         Opera: /version\/([\d\w\.\-]+)/i,
         Ps3: /([\d\w\.\-]+)\)\s*$/i,
@@ -174,7 +174,7 @@ var UserAgent = function() {
                     return RegExp.$1;
                 }
                 break;
-			case 'Chromium':
+            case 'Chromium':
                 if (this._Versions.Chromium.test(string)) {
                     return RegExp.$1;
                 }

--- a/tests/browsers.js
+++ b/tests/browsers.js
@@ -123,6 +123,38 @@ exports['Linux Chrome 17'] = function(test) {
     test.done();
 };
 
+
+exports['Linux Chromium 39'] = function(test) {
+
+    var s = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)'
+        + ' Ubuntu Chromium/39.0.2171.65 Chrome/39.0.2171.65 Safari/537.36';
+
+    var a = ua.parse(s);
+
+    test.ok(!a.isMobile, 'Mobile');
+    test.ok(!a.isiPad, 'iPad');
+    test.ok(!a.isiPod, 'iPod');
+    test.ok(!a.isiPhone, 'iPhone');
+    test.ok(!a.isAndroid, 'Android');
+    test.ok(!a.isBlackberry, 'Blackberry');
+    test.ok(!a.isOpera, 'Opera');
+    test.ok(!a.isIE, 'IE');
+    test.ok(!a.isSafari, 'Safari');
+    test.ok(!a.isFirefox, 'Firefox');
+    test.ok(!a.isWebkit, 'Webkit');
+    test.ok(a.isChrome, 'Chrome');
+    test.ok(!a.isKonqueror, 'Konqueror');
+    test.ok(a.isDesktop, 'Desktop');
+    test.ok(!a.isWindows, 'Windows');
+    test.ok(a.isLinux, 'Linux');
+    test.ok(!a.isMac, 'Mac');
+    test.ok(!a.isWindowsPhone, 'Windows Phone');
+    test.equal(a.Version, '39.0.2171.65');
+    test.ok(!a.isIECompatibilityMode);
+
+    test.done();
+};
+
 exports['Linux Ephiphany 2.30'] = function(test) {
 
     var s = 'Mozilla/5.0 (X11; U; Linux i686; en-us) AppleWebKit/531.2+ (KHTML, like Gecko)'


### PR DESCRIPTION
For Chromium on Ubuntu, the Browser is correctly being identified but Version is undefined. Added support for both 'chromium' and 'crios' in the UA string.
